### PR TITLE
Add AI clip generator page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import UserDetail from "./pages/UserDetail";
 import ChatHistory from "./pages/ChatHistory";
 import Subtitle from "./pages/Subtitle";
 import RandomBox from "./pages/RandomBox";
+import ClipGenerator from "./pages/ClipGenerator";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
 import HealthStatus from "./components/HealthStatus";
@@ -43,6 +44,8 @@ function PageTitle() {
           return "자막";
         case "/random-box":
           return "랜덤 박스";
+        case "/clip-generator":
+          return "클립 생성기";
         default:
           return "홈";
       }
@@ -147,6 +150,7 @@ function AppContent() {
           <Route path="/user/:userId/chat" element={<ChatHistory />} />
           <Route path="/subtitle" element={<Subtitle />} />
           <Route path="/random-box" element={<RandomBox />} />
+          <Route path="/clip-generator" element={<ClipGenerator />} />
           <Route path="/" element={<Navigate to="/subtitle" replace />} />
         </Routes>
       </main>

--- a/src/api/channel.ts
+++ b/src/api/channel.ts
@@ -116,3 +116,23 @@ export const getTranscripts = async (
     throw error;
   }
 };
+
+export interface Clip {
+  id: number;
+  createdAt: string;
+  title: string;
+  videoUrl: string;
+  thumbnailUrl: string;
+}
+
+export const getClips = async (
+  channelId: string
+): Promise<Clip[]> => {
+  try {
+    const response = await apiClient.get(`/channel/${channelId}/clip`);
+    return response.data;
+  } catch (error) {
+    console.error("클립 조회 실패:", error);
+    throw error;
+  }
+};

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,6 +7,7 @@ const Header = () => {
     location.pathname.startsWith("/user");
   const isSubtitlePage = location.pathname.startsWith("/subtitle");
   const isRandomBoxPage = location.pathname.startsWith("/random-box");
+  const isClipPage = location.pathname.startsWith("/clip-generator");
 
   return (
     <header>
@@ -30,6 +31,12 @@ const Header = () => {
               className={`dropdown-trigger ${isRandomBoxPage ? "active" : ""}`}
             >
               후원 랜덤박스
+            </Link>
+            <Link
+              to="/clip-generator"
+              className={`dropdown-trigger ${isClipPage ? "active" : ""}`}
+            >
+              AI 클립생성기
             </Link>
           </div>
         </div>

--- a/src/pages/ClipGenerator.tsx
+++ b/src/pages/ClipGenerator.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from "react";
+import ChannelNavigator from "../components/ChannelNavigator";
+import { Channel, Clip, getClips } from "../api/channel";
+import "../styles/ClipGenerator.css";
+
+const ClipGenerator = () => {
+  const [selectedChannel, setSelectedChannel] = useState<Channel | null>(null);
+  const [clips, setClips] = useState<Clip[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const fetchClips = async () => {
+      if (!selectedChannel) return;
+      try {
+        setLoading(true);
+        const data = await getClips(selectedChannel.uuid);
+        setClips(data);
+      } catch (error) {
+        console.error("클립 조회 실패:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchClips();
+  }, [selectedChannel]);
+
+  return (
+    <div className="subtitle-page">
+      <div className="subtitle-layout">
+        <div className="subtitle-sidebar">
+          <ChannelNavigator
+            selectedChannel={selectedChannel}
+            onChannelSelect={setSelectedChannel}
+          />
+        </div>
+        <div className="subtitle-main">
+          <div className="subtitle-container">
+            {!selectedChannel && (
+              <div className="subtitle-placeholder">텅...</div>
+            )}
+            {loading && <div className="loading">로딩 중...</div>}
+            {selectedChannel && !loading && clips.length === 0 && (
+              <div className="subtitle-placeholder">생성된 클립이 없습니다</div>
+            )}
+            <div className="clip-list">
+              {clips.map((clip) => (
+                <div key={clip.id} className="clip-item">
+                  <div className="clip-thumb">
+                    <img src={clip.thumbnailUrl} alt={clip.title} />
+                  </div>
+                  <div className="clip-info">
+                    <div className="clip-title">{clip.title}</div>
+                    <a
+                      href={clip.videoUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="clip-link"
+                    >
+                      보기
+                    </a>
+                    <div className="clip-time">
+                      {new Date(clip.createdAt).toLocaleString()}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ClipGenerator;

--- a/src/styles/ClipGenerator.css
+++ b/src/styles/ClipGenerator.css
@@ -1,0 +1,54 @@
+.clip-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  overflow-y: auto;
+  padding-top: 1rem;
+}
+
+.clip-item {
+  display: flex;
+  gap: 1rem;
+  background-color: #2a2a2a;
+  border: 1px solid #3a3a3a;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.clip-thumb img {
+  width: 160px;
+  height: 90px;
+  object-fit: cover;
+  display: block;
+}
+
+.clip-info {
+  display: flex;
+  flex-direction: column;
+  padding: 0.75rem;
+  flex: 1;
+}
+
+.clip-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #fff;
+  margin-bottom: 0.5rem;
+}
+
+.clip-link {
+  color: var(--primary-color);
+  text-decoration: none;
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+}
+
+.clip-link:hover {
+  text-decoration: underline;
+}
+
+.clip-time {
+  font-size: 0.8rem;
+  color: #888;
+  margin-top: auto;
+}


### PR DESCRIPTION
## Summary
- create ClipGenerator page to list generated clips by channel
- support fetching clips via new API
- link AI 클립생성기 in Header and routing

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing type declarations and modules)*

------
https://chatgpt.com/codex/tasks/task_e_683ff3be7fac832ab7362ab23a204876