### PR TITLE
Add mock clips data for testing

### DIFF
--- a/src/api/randomBox.ts
+++ b/src/api/randomBox.ts
@@ -1,4 +1,3 @@
-import { Channel } from "./channel";
 
 export interface BoxItem {
   id: number;

--- a/src/pages/ClipGenerator.tsx
+++ b/src/pages/ClipGenerator.tsx
@@ -3,6 +3,30 @@ import ChannelNavigator from "../components/ChannelNavigator";
 import { Channel, Clip, getClips } from "../api/channel";
 import "../styles/ClipGenerator.css";
 
+const mockClips: Clip[] = [
+  {
+    id: 1,
+    createdAt: "2024-04-01T12:00:00Z",
+    title: "첫 번째 하이라이트",
+    videoUrl: "https://example.com/video1",
+    thumbnailUrl: "https://via.placeholder.com/160x90?text=Clip+1",
+  },
+  {
+    id: 2,
+    createdAt: "2024-04-02T15:30:00Z",
+    title: "두 번째 하이라이트",
+    videoUrl: "https://example.com/video2",
+    thumbnailUrl: "https://via.placeholder.com/160x90?text=Clip+2",
+  },
+  {
+    id: 3,
+    createdAt: "2024-04-03T09:45:00Z",
+    title: "세 번째 하이라이트",
+    videoUrl: "https://example.com/video3",
+    thumbnailUrl: "https://via.placeholder.com/160x90?text=Clip+3",
+  },
+];
+
 const ClipGenerator = () => {
   const [selectedChannel, setSelectedChannel] = useState<Channel | null>(null);
   const [clips, setClips] = useState<Clip[]>([]);
@@ -14,9 +38,10 @@ const ClipGenerator = () => {
       try {
         setLoading(true);
         const data = await getClips(selectedChannel.uuid);
-        setClips(data);
+        setClips(data.length > 0 ? data : mockClips);
       } catch (error) {
         console.error("클립 조회 실패:", error);
+        setClips(mockClips);
       } finally {
         setLoading(false);
       }


### PR DESCRIPTION
## Summary
- add mock clip data sample
- fallback to mock clip data when fetching clips fails
- remove unused import in `randomBox` API

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683ffc1dbdbc832a8a832d3ecafbf926